### PR TITLE
Fix paragraph label in TOC when it is following a subsubsubsection

### DIFF
--- a/imta_core.sty
+++ b/imta_core.sty
@@ -490,16 +490,22 @@
 \newcommand\subsubsubsection{}                           % We create a new command
 \titleclass{\subsubsubsection}{straight}[\subsubsection] % Make it a title command
 \newcounter{subsubsubsection}[subsubsection]             % We create a new counter that inherits from subsubsection
+
+% Redefine labels
+\renewcommand\thesubsubsubsection{\thesubsubsection.\arabic{subsubsubsection}}
+\renewcommand\theparagraph{\thesubsubsubsection.\arabic{paragraph}}
+\renewcommand\thesubparagraph{\theparagraph.\arabic{subparagraph}}
+
 \renewcommand\thesubsubsubsection{\thesubsubsection.\arabic{subsubsubsection}} % The complete counter is updated
 \titlespacing{\subsubsubsection}{0pt}{2em}{1em}                                % Spacing is updated
 \titleformat{\subsubsubsection}[hang]{\normalsize\it}                % Layout is updated
-{\thesubsubsubsection.}{1em}{\normalsize\it}[\normalsize] % Formatting is updated
+{\thesubsubsubsection}{1em}{\normalsize\it}[\normalsize] % Formatting is updated
 
 % Adjusting Table Of Contents levels for the \subsubsubsection
 \makeatletter
     \setcounter{tocdepth}{6} % We increase the level of visibility in the TOC
     \def\toclevel@subsubsubsection{4}
-    \def\l@subsubsubsection{\@dottedtocline{5}{11em}{5em}}
+    \def\l@subsubsubsection{\@dottedtocline{4}{11em}{5em}}
     \def\toclevel@paragraph{5}
     \def\l@paragraph{\@dottedtocline{5}{14em}{6em}}
     \def\toclevel@subparagraph{6}


### PR DESCRIPTION
A number was missing in the table of content when a paragraph was directly following a subsubsubsection.

**Before :**
![before](https://user-images.githubusercontent.com/7689997/63012988-86a1e800-be8b-11e9-9c96-0ccb14256b73.png)

**After :** 
![after](https://user-images.githubusercontent.com/7689997/63013001-8dc8f600-be8b-11e9-8ea9-320c264ff6cd.png)
